### PR TITLE
Refactor no sanitizer window location

### DIFF
--- a/lib/rules/no-sanitizer-window-location.js
+++ b/lib/rules/no-sanitizer-window-location.js
@@ -10,7 +10,6 @@
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 const composeConfig = require('../util/composeConfig');
-const getNodeName = require('../util/getNodeName');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -55,85 +54,116 @@ module.exports = {
      * Checks for violation of rule
      * @param {ASTNode} node The AST node being checked.
      */
-    function checkForViolation(node) {
+    function checkForViolationWhenAssigning(node) {
       const expression = astUtil.getComponentProperties(node);
 
-      if (expression.type === 'AssignmentExpression') {
-        if (expression.left.type === 'MemberExpression') {
-          // check if property of window is location
-          if (
-            expression.left.object &&
-            expression.left.object.name === 'window' &&
-            expression.left.property &&
-            expression.left.property.name === 'location' &&
-            (expression.right.type === 'Literal' ||
-              expression.right.type === 'Identifier' ||
-              (expression.right.type === 'CallExpression' &&
-                expression.right.callee.type === 'Identifier' &&
-                config.wrapperName.indexOf(expression.right.callee.name) === -1))
-          ) {
-            context.report({
-              node: node,
-              message: `ERROR - ${getNodeName(node)} has violation code(s) : XSS attack : ${astUtil.getPropertyName(
-                expression.left
-              )}`
-            });
-
-            return;
+      if (
+        expression.type === 'AssignmentExpression' &&
+        checkWindowLocationProperty(expression.left) &&
+        (expression.right.type === 'Literal' ||
+          (expression.right.type === 'CallExpression' &&
+            expression.right.callee.type === 'Identifier' &&
+            config.wrapperName.indexOf(expression.right.callee.name) === -1))
+      ) {
+        return context.report({
+          node: node,
+          message: '',
+          data: {
+            name: 'window.location',
+            wrapperName: JSON.stringify(config.wrapperName)
           }
-          // check if property of window is hash
-          else if (
-            expression.left.object.object &&
-            expression.left.object.object.name === 'window' &&
-            expression.left.object.property &&
-            expression.left.object.property.name === 'location' &&
-            expression.left.property.name === 'hash' &&
-            (expression.right.type === 'Literal' ||
-              expression.right.type === 'Identifier' ||
-              (expression.right.type === 'CallExpression' &&
-                expression.right.callee.type === 'Identifier' &&
-                config.wrapperName.indexOf(expression.right.callee.name) === -1))
-          ) {
-            context.report({
-              node: node,
-              message: `ERROR - ${getNodeName(node)} has violation code(s) : XSS attack : ${astUtil.getPropertyName(
-                expression.left
-              )}`
-            });
-
-            return;
-          }
-        }
-      }
-      // check if property of window is location.assign
-      else if (
+        });
+      } else if (
         expression.type === 'CallExpression' &&
-        expression.callee.object &&
-        expression.callee.object.object &&
-        expression.callee.object.object.name === 'window' &&
-        expression.callee.object.property.name === 'location' &&
-        expression.callee.property.name === 'assign' &&
+        checkWindowLocationProperty(expression) &&
         (expression.arguments[0].type === 'Literal' ||
-          expression.arguments[0].type === 'Identifier' ||
           (expression.arguments[0].type === 'CallExpression' &&
             expression.arguments[0].callee.type === 'Identifier' &&
             config.wrapperName.indexOf(expression.arguments[0].callee.name) === -1))
       ) {
-        context.report({
+        return context.report({
           node: node,
-          message: `ERROR - ${getNodeName(node)} has violation code(s) : XSS attack : ${astUtil.getPropertyName(
-            expression.callee
-          )}`
+          message: '',
+          data: {
+            name: 'window.location',
+            wrapperName: JSON.stringify(config.wrapperName)
+          }
         });
+      }
 
-        return;
+      return;
+    }
+
+    function checkForViolationWhenReading(node) {
+      const declarations = astUtil.getComponentProperties(node)[0];
+
+      if (
+        declarations &&
+        declarations.init &&
+        ((declarations.init.type === 'MemberExpression' && checkWindowLocationProperty(declarations.init)) ||
+          (declarations.init.type === 'CallExpression' &&
+            checkWindowLocationProperty(declarations.init.arguments[0]) &&
+            config.wrapperName.indexOf(declarations.init.callee.name) === -1))
+      ) {
+        return context.report({
+          node: node,
+          message: '',
+          data: {
+            name: 'window.location',
+            wrapperName: JSON.stringify(config.wrapperName)
+          }
+        });
       }
 
       return;
     }
 
     return {
-      ExpressionStatement: checkForViolation
+      ExpressionStatement: checkForViolationWhenAssigning,
+      VariableDeclaration: checkForViolationWhenReading
     };
   }
 };
+
+function checkWindowLocationProperty(target) {
+  if (
+    (target.type === 'MemberExpression' &&
+      target.object &&
+      target.object.type === 'Identifier' &&
+      target.object.name === 'window' &&
+      target.property &&
+      target.property.type === 'Identifier' &&
+      target.property.name === 'location') ||
+    (target.type === 'MemberExpression' &&
+      target.object &&
+      target.object.type === 'MemberExpression' &&
+      target.object.object &&
+      target.object.object.type === 'Identifier' &&
+      target.object.object.name === 'window' &&
+      target.object.property &&
+      target.object.property.type === 'Identifier' &&
+      target.object.property.name === 'location' &&
+      ['hash', 'href', 'search', 'origin', 'host', 'hostname', 'pathname'].indexOf(target.property.name) > -1)
+  ) {
+    return true;
+  } else if (
+    target.type === 'CallExpression' &&
+    target.callee &&
+    target.callee.type === 'MemberExpression' &&
+    target.callee.object &&
+    target.callee.object.type === 'MemberExpression' &&
+    target.callee.object.object &&
+    target.callee.object.object.type === 'Identifier' &&
+    target.callee.object.object.name === 'window' &&
+    target.callee.object.property &&
+    target.callee.object.property.type === 'Identifier' &&
+    target.callee.object.property.name === 'location' &&
+    target.callee.property &&
+    target.callee.property.type === 'Identifier' &&
+    target.callee.property.name === 'assign'
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -53,6 +53,8 @@ function getComponentProperties(node) {
       return node.properties;
     case 'ExpressionStatement':
       return node.expression;
+    case 'VariableDeclaration':
+      return node.declarations;
     default:
       return [];
   }

--- a/tests/lib/rules/no-sanitizer-window-location.js
+++ b/tests/lib/rules/no-sanitizer-window-location.js
@@ -19,6 +19,7 @@ var ruleTester = new RuleTester();
 ruleTester.run('no-sanitizer-window-location', rule, {
   // valid example codes
   valid: [
+    // assigning
     {
       code: 'window.location = sanitizer("/path#unpurifiedString");'
     },
@@ -36,6 +37,25 @@ ruleTester.run('no-sanitizer-window-location', rule, {
     },
     {
       code: 'window.location.assign(sanitizer(unpurifiedVar));'
+    },
+    // reading
+    {
+      code: 'var windowLocation = sanitizer(window.location);'
+    },
+    {
+      code: 'var windowLocation = sanitizer(window.location.origin);'
+    },
+    {
+      code: 'var windowLocation = sanitizer(window.location.hash);'
+    },
+    {
+      code: 'var windowLocation = sanitizer(window.location.host);'
+    },
+    {
+      code: 'var windowLocation = sanitizer(window.location.hostname);'
+    },
+    {
+      code: 'var windowLocation = sanitizer(window.location.pathname);'
     }
   ],
   // invalid example codes
@@ -87,6 +107,16 @@ ruleTester.run('no-sanitizer-window-location', rule, {
     },
     {
       code: 'window.location.assign(unpurifiedVar);',
+      errors: [
+        {
+          message: 'File contains violation code(s) of XSS attack',
+          type: 'Cross Site Scripting (XSS)'
+        }
+      ]
+    },
+    // reading
+    {
+      code: 'var windowLocation = window.location;',
       errors: [
         {
           message: 'File contains violation code(s) of XSS attack',


### PR DESCRIPTION
- Refactor ugly conditions.
- Detect violation coding when not only assigning but also reading `window.location`.