### PR TITLE
no-sanitizer-with-danger: Add fixer function

### DIFF
--- a/lib/rules/no-sanitizer-with-danger.js
+++ b/lib/rules/no-sanitizer-with-danger.js
@@ -70,7 +70,8 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    fixable: 'code',
   },
 
   create: function(context) {
@@ -98,13 +99,20 @@ module.exports = {
         }
 
         if (messageIndex >= 0) {
+          const htmlProp = node.value.expression.properties.find(prop => prop.key.name === '__html');
           context.report({
             node: node,
             message: DANGEROUS_MESSAGES[messageIndex],
             data: {
               name: node.name.name,
               wrapperName: JSON.stringify(config.wrapperName)
-            }
+            },
+            fix(fixer) {
+              return fixer.replaceText(
+                htmlProp.value,
+                `${config.wrapperName[0]}(${context.getSourceCode().getText(htmlProp.value)})`
+              );
+            },
           });
         }
       }

--- a/lib/rules/no-sanitizer-with-danger.js
+++ b/lib/rules/no-sanitizer-with-danger.js
@@ -71,7 +71,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    fixable: 'code',
+    fixable: 'code'
   },
 
   create: function(context) {

--- a/lib/rules/no-sanitizer-with-danger.js
+++ b/lib/rules/no-sanitizer-with-danger.js
@@ -100,20 +100,25 @@ module.exports = {
 
         if (messageIndex >= 0) {
           const htmlProp = node.value.expression.properties.find(prop => prop.key.name === '__html');
-          context.report({
+          const reportOptions = {
             node: node,
             message: DANGEROUS_MESSAGES[messageIndex],
             data: {
               name: node.name.name,
               wrapperName: JSON.stringify(config.wrapperName)
-            },
-            fix(fixer) {
+            }
+          };
+
+          if (messageIndex !== 2) {
+            reportOptions.fix = function(fixer) {
               return fixer.replaceText(
                 htmlProp.value,
                 `${config.wrapperName[0]}(${context.getSourceCode().getText(htmlProp.value)})`
               );
-            },
-          });
+            };
+          }
+
+          context.report(reportOptions);
         }
       }
     };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     {
       "name": "Iran Reyes",
       "url": "https://github.com/iranreyes"
+    },
+    {
+      "name": "Sean Mizen",
+      "url": "https://github.com/seanmizen"
     }
   ],
   "main": "lib/index.js",

--- a/tests/lib/rules/no-sanitizer-with-danger.js
+++ b/tests/lib/rules/no-sanitizer-with-danger.js
@@ -51,32 +51,40 @@ ruleTester.run('no-sanitizer-with-danger', rule, {
   invalid: [
     {
       code: "<App dangerouslySetInnerHTML={{ __html: '<p>with sanitizer</p>' }} />;",
-      errors: [NO_SANITIZER_PATTERN]
+      errors: [NO_SANITIZER_PATTERN],
+      output: "<App dangerouslySetInnerHTML={{ __html: sanitizer('<p>with sanitizer</p>') }} />;"
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: '' }}></div>;",
-      errors: [NO_SANITIZER_PATTERN]
+      errors: [NO_SANITIZER_PATTERN],
+      output: "<div dangerouslySetInnerHTML={{ __html: sanitizer('') }}></div>;"
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: '<p>with sanitizer</p>' }} />;",
-      errors: [NO_SANITIZER_PATTERN]
+      errors: [NO_SANITIZER_PATTERN],
+      output: "<div dangerouslySetInnerHTML={{ __html: sanitizer('<p>with sanitizer</p>') }} />;"
     },
     {
       code: '<div dangerouslySetInnerHTML={{ __html: title }} />;',
-      errors: [NO_SANITIZER_PATTERN]
+      errors: [NO_SANITIZER_PATTERN],
+      output: '<div dangerouslySetInnerHTML={{ __html: sanitizer(title) }} />;'
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: invalidSanitizer('<p>with sanitizer</p>') }} />;",
-      errors: [BAD_WRAPPER_PATTERN]
+      errors: [BAD_WRAPPER_PATTERN],
+      output: "<div dangerouslySetInnerHTML={{ __html: sanitizer(invalidSanitizer('<p>with sanitizer</p>')) }} />;"
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: Dompurify.sanitizer('<p>with sanitizer</p>') }} />;",
-      errors: [{ message: XSS_LIBRARY_MESSAGE }]
+      errors: [{ message: XSS_LIBRARY_MESSAGE }],
+      // do not handle direct use of library
+      output: "<div dangerouslySetInnerHTML={{ __html: Dompurify.sanitizer('<p>with sanitizer</p>') }} />;"
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: sanitize('<p>with sanitizer</p>') }} />;",
       options: [{ wrapperName: ['xss', 'purify'] }],
-      errors: [BAD_WRAPPER_PATTERN]
+      errors: [BAD_WRAPPER_PATTERN],
+      output: "<div dangerouslySetInnerHTML={{ __html: xss(sanitize('<p>with sanitizer</p>')) }} />;"
     }
   ]
 });

--- a/tests/lib/rules/no-sanitizer-with-danger.js
+++ b/tests/lib/rules/no-sanitizer-with-danger.js
@@ -7,7 +7,9 @@
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
-const MESSAGE = 'Use xss sanitizer with dangerouslySetInnerHTML';
+const NO_SANITIZER_PATTERN = /Dangerous property '\s+' without sanitizer found./;
+const BAD_WRAPPER_PATTERN = /Wrapper name is not one of '\[.*\]'\./;
+const XSS_LIBRARY_MESSAGE = 'Direct use of xss library found.';
 
 // ------------------------------------------------------------------------------
 // Requirements
@@ -49,32 +51,32 @@ ruleTester.run('no-sanitizer-with-danger', rule, {
   invalid: [
     {
       code: "<App dangerouslySetInnerHTML={{ __html: '<p>with sanitizer</p>' }} />;",
-      errors: [{ message: MESSAGE }]
+      errors: [NO_SANITIZER_PATTERN]
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: '' }}></div>;",
-      errors: [{ message: MESSAGE }]
+      errors: [NO_SANITIZER_PATTERN]
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: '<p>with sanitizer</p>' }} />;",
-      errors: [{ message: MESSAGE }]
+      errors: [NO_SANITIZER_PATTERN]
     },
     {
       code: '<div dangerouslySetInnerHTML={{ __html: title }} />;',
-      errors: [{ message: MESSAGE }]
+      errors: [NO_SANITIZER_PATTERN]
     },
     {
-      code: "<div dangerouslySetInnerHTML={{ __html: sanitize('<p>with sanitizer</p>') }} />;",
-      errors: [{ message: 'Use sanitizer as name of wrapper' }]
+      code: "<div dangerouslySetInnerHTML={{ __html: invalidSanitizer('<p>with sanitizer</p>') }} />;",
+      errors: [BAD_WRAPPER_PATTERN]
     },
     {
       code: "<div dangerouslySetInnerHTML={{ __html: Dompurify.sanitizer('<p>with sanitizer</p>') }} />;",
-      errors: [{ message: 'Use sanitizer in util folder. Create sanitizer util if no exist.' }]
+      errors: [{ message: XSS_LIBRARY_MESSAGE }]
     },
     {
-      code: "<div dangerouslySetInnerHTML={{ __html: sanitizer('<p>with sanitizer</p>') }} />;",
+      code: "<div dangerouslySetInnerHTML={{ __html: sanitize('<p>with sanitizer</p>') }} />;",
       options: [{ wrapperName: ['xss', 'purify'] }],
-      errors: [{ message: 'Use sanitizer in util folder. Create sanitizer util if no exist.' }]
+      errors: [BAD_WRAPPER_PATTERN]
     }
   ]
 });


### PR DESCRIPTION
## Add fixer function - wrap in wrapperName[0]

Wraps the value of `__html: <value>` to `__html: sanitizer(<value>)`. Uses wrapperName[0] as the preferred sanitizer function.

Assume the repo has wrapperName[0] (e.g. `sanitizer`) available as a function.

Does **not** auto-import the sanitizer function.

___

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

Unit tests written. Problem: tests for the other two rules failing - possibly a node or npm version issue on my end?

## Problem Description

Problem: the helper messages are nice but the library does not provide an auto-fixer for developers. We see some value in this as it will disambiguate the error messages by simply solving the issue.

1: `"Dangerous property '{{name}}' without sanitizer found."`

This not specify the name of the sanitizer - for a large org or codebase how does the developer know which sanitizer to use? There is potential confusion here.

2: `"Wrapper name is not one of '{{wrapperName}}'.",`

While this does help, a developer might take this as a signal to _replace_ the current outermost wrapper instead of wrapping it with the sanitizer (the intended behaviour).

Here is the scenario:

Developer thinks he should replace `__html: textFormatterFunctionNotRelatedToSanitization(<value>)` with `__html: sanitizer(<value>)`.

## Solution Description

Replaces this:
```
<div
  dangerouslySetInnerHTML={{
    __html: dangerousContent,
  }}
/>
```
with this:
```
<div
  dangerouslySetInnerHTML={{
    __html: sanitizeHtml(dangerousContent),
  }}
/>
```

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

This is my first FOSS PR.